### PR TITLE
fix: clean changelog output for Jira

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,6 @@
+formatter:
+  page_width: 120
+
 linter:
   rules:
     public_member_api_docs: false

--- a/lib/src/commands/changelog/changelog_command.dart
+++ b/lib/src/commands/changelog/changelog_command.dart
@@ -27,9 +27,8 @@ class ChangelogCommand extends Command<int> {
       }
 
       final String version = argResults!.rest.first;
-      final List<String> versionChanges = await ChangelogExtractor.extractForVersion(version);
+      final List<String> versionChanges = await ChangelogExtractor.extractCompactForVersion(version);
 
-      _logger.info('Changelog for version $version:\n');
       _logger.info(versionChanges.join('\n'));
 
       return ExitCode.success.code;

--- a/lib/src/commands/jira/jira_webhook_command.dart
+++ b/lib/src/commands/jira/jira_webhook_command.dart
@@ -1,13 +1,13 @@
- import 'dart:convert';
-import 'dart:io';
+import 'dart:convert';
 
 import 'package:args/command_runner.dart';
 import 'package:humm_cli/src/args/common_args/common_flags_handler.dart';
 import 'package:humm_cli/src/core/environment/environment_config.dart';
 import 'package:humm_cli/src/core/exceptions/exception_handler.dart';
 import 'package:humm_cli/src/core/exceptions/exceptions.dart';
-import 'package:mason_logger/mason_logger.dart';
+import 'package:humm_cli/src/services/files/changelog_extractor.dart';
 import 'package:http/http.dart' as http;
+import 'package:mason_logger/mason_logger.dart';
 
 /// Sends a changelog to a Jira webhook.
 class JiraSendChangelogWebookCommand extends Command<int> {
@@ -31,7 +31,7 @@ class JiraSendChangelogWebookCommand extends Command<int> {
       throw const FormatException('Version argument is required');
     }
 
-    String releaseVersion = argResults!.rest.first;
+    final String releaseVersion = argResults!.rest.first;
 
     final String? jiraWebhookUrl = EnvironmentConfig.getWebhook(app: WebhookApp.jira);
 
@@ -39,23 +39,13 @@ class JiraSendChangelogWebookCommand extends Command<int> {
       throw NoWebhooksConfiguredException('No Jira webhook found.');
     }
 
-    String? jiraWebhookToken = EnvironmentConfig.getAuthToken(app: WebhookAuthTokens.jira);
+    final String? jiraWebhookToken = EnvironmentConfig.getAuthToken(app: WebhookAuthTokens.jira);
 
     if (jiraWebhookToken == null || jiraWebhookToken.isEmpty) {
       throw NoAuthTokenException('Jira token not provided.');
     }
 
-    // Run the changelog command
-    ProcessResult result = await Process.run('humm', <String>['changelog', releaseVersion]);
-
-    if (argResults!.rest.isEmpty) {
-      throw const FormatException('Version argument is required');
-    }
-
-    String changelog = result.stdout.toString().trim();
-    if (result.exitCode != 0) {
-      changelog += "\nError: " + result.stderr.toString().trim();
-    }
+    final String changelog = (await ChangelogExtractor.extractCompactForVersion(releaseVersion)).join('\n');
 
     _logger.info('Raw changelog output:');
     _logger.info(changelog);
@@ -71,10 +61,10 @@ class JiraSendChangelogWebookCommand extends Command<int> {
 
     // Format the changelog for readability in Jira
     // Keep this simple to avoid breaking the regex matching
-    String formattedChangelog = changelog;
+    final String formattedChangelog = changelog;
 
     // Prepare the JSON payload
-    Map<String, dynamic> payload = <String, dynamic>{
+    final Map<String, dynamic> payload = <String, dynamic>{
       'issues': taskNumbers,
       'data': <String, String>{
         'changelog': formattedChangelog,
@@ -82,7 +72,7 @@ class JiraSendChangelogWebookCommand extends Command<int> {
       }
     };
 
-    String jsonPayload = jsonEncode(payload);
+    final String jsonPayload = jsonEncode(payload);
     _logger.info('Payload: $jsonPayload');
     try {
       final http.Response response = await http.post(
@@ -107,7 +97,7 @@ class JiraSendChangelogWebookCommand extends Command<int> {
   }
 
   List<String> _extractTaskNumbers(String text) {
-    final List<String> taskNumbers = <String>[];
+    final Set<String> taskNumbers = <String>{};
 
     final RegExp jiraPattern = RegExp(r'[A-Z]+-\d+');
     final Iterable<RegExpMatch> jiraMatches = jiraPattern.allMatches(text);
@@ -121,6 +111,6 @@ class JiraSendChangelogWebookCommand extends Command<int> {
       taskNumbers.add(match.group(1)!);
     }
 
-    return taskNumbers;
+    return taskNumbers.toList();
   }
 }

--- a/lib/src/services/files/changelog_extractor.dart
+++ b/lib/src/services/files/changelog_extractor.dart
@@ -1,4 +1,4 @@
- import 'dart:io';
+import 'dart:io';
 
 import 'package:humm_cli/src/core/exceptions/exceptions.dart';
 
@@ -7,16 +7,16 @@ abstract class ChangelogExtractor {
   /// Returns a list of lines containing the changelog
   static Future<List<String>> extractForVersion(String version) async {
     final File changelog = File('CHANGELOG.md');
-    
+
     if (!changelog.existsSync()) {
       throw NoChangelogFileFoundException();
     }
-    
+
     final List<String> changelogContent = changelog.readAsLinesSync();
     final List<String> versionChanges = <String>[];
     bool isVersionFound = false;
     bool isCollecting = false;
-    
+
     for (final String line in changelogContent) {
       if (line.contains('# $version')) {
         isVersionFound = true;
@@ -24,20 +24,44 @@ abstract class ChangelogExtractor {
         versionChanges.add(line);
         continue;
       }
-      
+
       if (isCollecting && line.startsWith('# ')) {
         break;
       }
-      
+
       if (isCollecting) {
         versionChanges.add(line);
       }
     }
-    
+
     if (!isVersionFound) {
       throw WrongVersionProvidedException();
     }
-    
+
     return versionChanges;
+  }
+
+  /// Extracts a compact changelog for comments and release notes.
+  static Future<List<String>> extractCompactForVersion(String version) async {
+    final List<String> versionChanges = await extractForVersion(version);
+
+    return versionChanges.where((String line) {
+      final String trimmedLine = line.trim();
+      return trimmedLine.isNotEmpty;
+    }).map((String line) {
+      final String trimmedLine = line.trim();
+      if (trimmedLine.startsWith('# ')) {
+        return trimmedLine.substring(2);
+      }
+
+      return trimmedLine;
+    }).toList();
+  }
+
+  /// Extracts only release note entries for a specific version.
+  static Future<List<String>> extractEntriesForVersion(String version) async {
+    final List<String> versionChanges = await extractCompactForVersion(version);
+
+    return versionChanges.where((String line) => !line.startsWith(RegExp(r'\d+\.\d+\.\d+'))).toList();
   }
 }

--- a/test/changelog_extractor_test.dart
+++ b/test/changelog_extractor_test.dart
@@ -1,0 +1,62 @@
+import 'dart:io';
+
+import 'package:humm_cli/src/services/files/changelog_extractor.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Directory previousDirectory;
+  late Directory tempDirectory;
+
+  setUp(() {
+    previousDirectory = Directory.current;
+    tempDirectory = Directory.systemTemp.createTempSync('humm_changelog_test_');
+    Directory.current = tempDirectory;
+  });
+
+  tearDown(() {
+    Directory.current = previousDirectory;
+    tempDirectory.deleteSync(recursive: true);
+  });
+
+  test('extractCompactForVersion returns header and entries without empty lines', () async {
+    File('CHANGELOG.md').writeAsStringSync('''
+# 4.0.48 [29.06.2026 16:33]
+
+- [fix] Fixed bottom overlay on Android. [SSO-74]
+- [improvement] Added white background on webview open. [SS0-74]
+# 4.0.47 [29.06.2026 14:49]
+
+- [feature] Removed buttons on home.
+''');
+
+    final List<String> changes = await ChangelogExtractor.extractCompactForVersion('4.0.48');
+
+    expect(
+      changes,
+      <String>[
+        '4.0.48 [29.06.2026 16:33]',
+        '- [fix] Fixed bottom overlay on Android. [SSO-74]',
+        '- [improvement] Added white background on webview open. [SS0-74]',
+      ],
+    );
+  });
+
+  test('extractEntriesForVersion returns only release note items', () async {
+    File('CHANGELOG.md').writeAsStringSync('''
+# 4.0.48 [29.06.2026 16:33]
+
+- [fix] Fixed bottom overlay on Android. [SSO-74]
+- [improvement] Added white background on webview open. [SS0-74]
+''');
+
+    final List<String> changes = await ChangelogExtractor.extractEntriesForVersion('4.0.48');
+
+    expect(
+      changes,
+      <String>[
+        '- [fix] Fixed bottom overlay on Android. [SSO-74]',
+        '- [improvement] Added white background on webview open. [SS0-74]',
+      ],
+    );
+  });
+}


### PR DESCRIPTION
- Clean up `humm changelog` output so it no longer prints CLI labels like `Changelog for version ...`.
- Format changelog output as compact release notes: version header + entries without extra blank lines.
- Update `jira_changelog` to read changelog data directly instead of spawning `humm changelog`, preventing unrelated pub/CLI output from being sent to Jira.
- Deduplicate detected Jira issue keys before sending the webhook payload.